### PR TITLE
handle new error thrown by Vim 7.4

### DIFF
--- a/autoload/genutils.vim
+++ b/autoload/genutils.vim
@@ -248,7 +248,7 @@ function! genutils#RestoreActiveWindow()
     exec t:curWinnr'wincmd w'
   endif
   if t:curWinnr != t:prevWinnr
-    exec t:prevWinnr'wincmd w'
+    silent! exec t:prevWinnr'wincmd w'
     wincmd p
   endif
 endfunction


### PR DESCRIPTION
was silently ignored by tagselect.vim earlier anyway, this makes it explicit.
see <https://groups.google.com/forum/#!topic/vim_dev/KE3h0THwizc<
